### PR TITLE
Never pick argument for non-matching media query

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -63,10 +63,9 @@ function MediamuxProvider({ theme = defaultTheme, children }: Props) {
 
 function useMediamux() {
   const { matchingQueries } = React.useContext(MediamuxContext);
-  const matchingQueriesCount = matchingQueries.filter((x: boolean) => x).length;
 
   return function mediamux<T>(...args: T[]) {
-    return args[Math.min(args.length - 1, matchingQueriesCount)];
+    return args.filter((_, i) => matchingQueries[i]).pop() || args[0];
   };
 }
 

--- a/test/index.test.tsx
+++ b/test/index.test.tsx
@@ -45,7 +45,7 @@ describe('it', () => {
       </MediamuxProvider>
     );
 
-    expect(queryByTestId('medium')).toBeTruthy();
+    expect(queryByTestId('small')).toBeTruthy();
   });
 
   it('renders second argument if matching first and second media-query', () => {
@@ -77,11 +77,21 @@ describe('it', () => {
       </MediamuxProvider>
     );
 
-    expect(queryByTestId('large')).toBeTruthy();
+    expect(queryByTestId('medium')).toBeTruthy();
   });
 
   it('picks last argument if active mediaquery index > argument array', () => {
     (window.matchMedia as any)
+      .mockImplementationOnce((query: any) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }))
       .mockImplementationOnce((query: any) => ({
         matches: true,
         media: query,
@@ -119,5 +129,48 @@ describe('it', () => {
     );
 
     expect(queryByTestId('medium')).toBeTruthy();
+  });
+
+  it('never picks argument for non-matching media query', () => {
+    (window.matchMedia as any)
+      .mockImplementationOnce((query: any) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }))
+      .mockImplementationOnce((query: any) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }))
+      .mockImplementationOnce((query: any) => ({
+        matches: true,
+        media: query,
+        onchange: null,
+        addListener: jest.fn(), // deprecated
+        removeListener: jest.fn(), // deprecated
+        addEventListener: jest.fn(),
+        removeEventListener: jest.fn(),
+        dispatchEvent: jest.fn(),
+      }));
+
+    const breakpoints = ['40em', '256em', '64em']; // Notice wrong order
+    const { queryByTestId } = render(
+      <MediamuxProvider theme={{ breakpoints }}>
+        <TestComponent />
+      </MediamuxProvider>
+    );
+
+    expect(queryByTestId('large')).toBeTruthy();
   });
 });


### PR DESCRIPTION
This PR fixes the unit tests as the code did not match the description.

It then makes sure the corrected tests pass. This way it is shorter and probably faster.

It fixes a case when the breakpoints are not strictly increasing (as a typo or intentionally). It never selects argument on the position that does not represent a matching media query. Except for the first item, that is returned when no match is found.